### PR TITLE
Expose utility functions through compile function.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -159,7 +159,7 @@
     "operator-assignment": 0,       // require assignment operator shorthand where possible or prohibit it entirely (off by default)
     "padded-blocks": 0,             // enforce padding within blocks (off by default)
     "quote-props": 0,               // require quotes around object literal property names (off by default)
-    "quotes": ["error", "double"],  // specify whether double or single quotes should be used
+    "quotes": ["error", "double", { "allowTemplateLiterals": true }],  // specify whether double or single quotes should be used
     "semi": 0,                      // require or disallow use of semicolons instead of ASI
     "sort-vars": 0,                 // sort variables within the same declaration block (off by default)
     "space-after-function-name": 0, // require a space after function names (off by default)

--- a/dist/momo.js
+++ b/dist/momo.js
@@ -2257,18 +2257,28 @@ function memoryDump(array, limit) {
 
 
 const defaultImports = {
-  log: console.log
+  log: console.log,
+  error: console.error
 };
 
-function compile(str, imports = {}, sync) {
+function compileSource(source, imports) {
   // reset
   compiler.reset(Object.assign({}, defaultImports, imports));
 
   // process
-  let tkns = scan(str);
+  let tkns = scan(source);
   let ast = parse(tkns);
   emit(ast);
-  let buffer = new Uint8Array(compiler.bytes);
+
+  return {
+    buffer: new Uint8Array(compiler.bytes),
+    ast,
+    tokens: tkns
+  };
+}
+
+function compile(str, imports = {}, sync) {
+  const { buffer, ast } = compileSource(str, imports);
   let dump = hexDump(buffer);
 
   // output
@@ -2299,6 +2309,8 @@ function compile(str, imports = {}, sync) {
   });
 }
 
+// Export internal functions
+compile.compileSource = compileSource;
 compile.scan = scan;
 compile.parse = parse;
 compile.emit = emit;

--- a/dist/momo.js
+++ b/dist/momo.js
@@ -2299,6 +2299,10 @@ function compile(str, imports = {}, sync) {
   });
 }
 
+compile.scan = scan;
+compile.parse = parse;
+compile.emit = emit;
+
 if (typeof window !== "undefined") {
   window.compile = compile;
   window.memoryDump = memoryDump;

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,11 @@ export default function compile(str, imports = {}, sync) {
   });
 };
 
+// Export internal functions
+compile.scan = scan;
+compile.parse = parse;
+compile.emit = emit;
+
 if (typeof window !== "undefined") {
   window.compile = compile;
   window.memoryDump = memoryDump;

--- a/src/index.js
+++ b/src/index.js
@@ -34,18 +34,28 @@ function loadStdlib() {
 };
 
 const defaultImports = {
-  log: console.log
+  log: console.log,
+  error: console.error
 };
 
-export default function compile(str, imports = {}, sync) {
+function compileSource(source, imports) {
   // reset
   compiler.reset(Object.assign({}, defaultImports, imports));
 
   // process
-  let tkns = scan(str);
+  let tkns = scan(source);
   let ast = parse(tkns);
   emit(ast);
-  let buffer = new Uint8Array(compiler.bytes);
+
+  return {
+    buffer: new Uint8Array(compiler.bytes),
+    ast,
+    tokens: tkns
+  };
+}
+
+export default function compile(str, imports = {}, sync) {
+  const { buffer, ast } = compileSource(str, imports);
   let dump = hexDump(buffer);
 
   // output
@@ -77,6 +87,7 @@ export default function compile(str, imports = {}, sync) {
 };
 
 // Export internal functions
+compile.compileSource = compileSource;
 compile.scan = scan;
 compile.parse = parse;
 compile.emit = emit;


### PR DESCRIPTION
Hey, check it out

I wrote a loader for `.momo` files.[ Momo-loader](https://github.com/ballercat/momo-loader). This little loader allows you to write momo syntax and directly import that into your JS and execute exports. It's pretty fun to mess around with.

Anywhoo, I needed to be able compile to binary format without generating an instance so I exported these functions on top of `compile`.

I think this simplification of wasm is a great idea as this is the fastest way to hack on WebAssembly right now.